### PR TITLE
update mysqld config

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,8 +1,8 @@
 # ss-panel
 #
-# VERSION 3.0
+# VERSION 3.1
 
-# auto build from my github project: https://github.com/maxidea-com/ss-panel
+# auto build from my github project: https://github.com/iliul/ss-panel
 
 FROM ubuntu:14.04 
 
@@ -18,7 +18,7 @@ RUN cd /opt; git clone -b manyuser https://github.com/mengskysama/shadowsocks.gi
 RUN rm -f /opt/shadowsocks/shadowsocks/Config.py
 RUN rm -f /opt/shadowsocks/shadowsocks/config.json
 RUN apt-get -y install supervisor
-RUN cd /opt; git clone https://github.com/maxidea-com/ss-panel.git
+RUN cd /opt; git clone https://github.com/iliul/ss-panel.git
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/bin --filename=composer
 RUN cd /opt/ss-panel/; composer install
 RUN chmod -R 777 /opt/ss-panel/storage
@@ -46,4 +46,4 @@ CMD ["/usr/bin/supervisord"]
 
 
 # contact
-MAINTAINER SimonXu, maxidea@gmail.com
+MAINTAINER iliul, liul.stone@gmail.com

--- a/docker/mysql-init.sh
+++ b/docker/mysql-init.sh
@@ -1,4 +1,10 @@
 #! /bin/bash
+
+echo "add mysqld config"
+sed -i -e '34a table_open_cache=128' /etc/mysql/my.cnf
+sed -i -e '34a table_definition_cache=200' /etc/mysql/my.cnf
+sed -i -e '34a performance_schema_max_table_instances=200' /etc/mysql/my.cnf
+
 sudo service mysql restart
 if [ $? -eq 0 ]; then
 	echo "mysql startup successful!"


### PR DESCRIPTION
解决当使用低内存VPS时，MYSQL启动时报错：

```
Version: '5.6.28-0ubuntu0.14.04.1'  socket: '/var/run/mysqld/mysqld.sock'  port: 3306  (Ubuntu)
161227 14:43:16 mysqld_safe Starting mysqld daemon with databases from /var/lib/mysql
Killed
```

修改配置`/etc/mysql/my.cnf`，增加了：

```
performance_schema_max_table_instances=200
table_definition_cache=200
table_open_cache=128
```